### PR TITLE
NOTIFY could be lost until some network activity happens while using the same connection for queries and listening

### DIFF
--- a/txpostgres/txpostgres.py
+++ b/txpostgres/txpostgres.py
@@ -550,6 +550,9 @@ class Connection(_PollingMixin):
         # a reader to a closed connection would be an error.
         if not self._connection.closed:
             self.reactor.addReader(self)
+            # While cursor was running, some notifies could have been
+            # delivered, so check for them.
+            self.doRead()
 
     def doRead(self):
         # call superclass to handle the pending read event on the socket


### PR DESCRIPTION
When cursor is finished, check for incoming notifies that could have been delivered to the connection while connection hasn't been registered as reader.
