### PR TITLE
Fixes the problem with gtk2 reactor.

### DIFF
--- a/txpostgres/txpostgres.py
+++ b/txpostgres/txpostgres.py
@@ -359,6 +359,13 @@ class Connection(_PollingMixin):
         d = self.poll()
         return d.addCallback(startReadingAndPassthrough)
 
+    @property
+    def disconnected(self):
+        # This attribute even though is not a part of IWriteDescriptor
+        # interface is used by gtk2reactor in Twisted 10.2.0.
+        # Without it txpostgres will not work under gtk reactor.
+        return self._connection.closed
+
     def close(self):
         """
         Close the connection and disconnect from the database.


### PR DESCRIPTION
In twisted 10.2 in gtk2reactor there is an attribute call on sth which is supposed to be IWriteDescriptor and is not the part of interface. The full code around line 294 of gtk2reactor.py looks like this:

``` python
    def _doReadOrWrite(self, source, condition, faildict={
        error.ConnectionDone: failure.Failure(error.ConnectionDone()),
        error.ConnectionLost: failure.Failure(error.ConnectionLost()),
        }):
        why = None
        inRead = False
        if condition & POLL_DISCONNECTED and not (condition & gobject.IO_IN):
            if source in self._reads:
                why = main.CONNECTION_DONE
                inRead = True
            else:
                why = main.CONNECTION_LOST
        else:
            try:
                if condition & gobject.IO_IN:
                    why = source.doRead()
                    inRead = True
                if not why and condition & gobject.IO_OUT:
                    # if doRead caused connectionLost, don't call doWrite
                    # if doRead is doWrite, don't call it again.
                    if not source.disconnected:
                        why = source.doWrite()
            except:
                why = sys.exc_info()[1]
                log.msg('Error In %s' % source)
                log.deferr()
```

The call source.disconnected failed with txpostgres as it didn't have this attribute.
