### PR TITLE
Add support for psycopg2-ctypes

### DIFF
--- a/test/test_txpostgres.py
+++ b/test/test_txpostgres.py
@@ -9,7 +9,10 @@ try:
     import psycopg2
     import psycopg2.extensions
 except ImportError:
-    psycopg2 = None
+    try:
+        import psycopg2ct as psycopg2
+    except ImportError:
+        psycopg2 = None
 
 from txpostgres import txpostgres
 

--- a/txpostgres/txpostgres.py
+++ b/txpostgres/txpostgres.py
@@ -7,7 +7,11 @@ A Twisted wrapper for the asynchronous features of the PostgreSQL psycopg2
 driver.
 """
 
-import psycopg2
+try:
+    import psycopg2
+except ImportError:
+    import psycopg2ct as psycopg2
+
 from zope.interface import implements
 
 from twisted.internet import interfaces, main, defer


### PR DESCRIPTION
Add support for psycopg2-ctypes (fix bug with binding connect function to object)
