### PR TITLE
Hook to allow implementation of reconnecting clients

### DIFF
--- a/doc/reconnecting_client_example.py
+++ b/doc/reconnecting_client_example.py
@@ -7,10 +7,10 @@ from txpostgres.txpostgres import ReconnectingConnection
 def print_query(conn, *_):
     conn.logger.debug('I am currently... %s, with %i pending requests', conn.state, len(conn.pending_requests.keys()))
 
-    conn.runQuery('select tablename from pg_tables').addCallback(println)
+    conn.runQuery('select tablename from pg_tables limit 5').addCallback(println)
 
 if __name__ == '__main__':
-    logging.basicConfig()
+    logging.basicConfig(level=logging.DEBUG)
     connection = ReconnectingConnection(database='postgres',
                                         user='diallictive',
                                         password='diallictive',


### PR DESCRIPTION
As mentionned in #23, having a ReconnectionConnection[Pool] would be nice when developping daemons and such.
So i made a ReconnectingClient (in doc/reconnecting_client_example.py), which requires a small hook in the _PollingMixin's .continuePolling() method.

This solution may not be the cleanest/most user friendly, but it WorksForMe® and will not break previous code or future code ignoring it.

Feel free to give feedback/rework the code of course.

Regards,
