### PR TITLE
Check file descriptor before attempting to re-add reader to reactor.

### DIFF
--- a/txpostgres/txpostgres.py
+++ b/txpostgres/txpostgres.py
@@ -682,7 +682,7 @@ class Connection(_PollingMixin):
         # other end of our connection, causing a fd = -1 which
         # will throw an error in the pollreactor.addReader
         if self.fileno() < 0:
-            self.connectionLost(failure.Failure(main.CONNECTION_DONE))
+            self.close()
             return
 
         # continue watching for NOTIFY events, but be careful to check the


### PR DESCRIPTION
Using:
Twisted-12.0.0
pyscopg2-2.5.1

By manually stopping postgresql with an active connection open, the connection is not being properly closed and the doRead function tries to add itself back into the reader list when it has a non-existent file descriptor (-1)

```
Traceback (most recent call last):
  File "/home/max/nxt/magdb/magdb/connection.py", line 25, in doRead
    txpostgres.Connection.doRead(self)
  File "/home/max/nxt/storesrv/venv/local/lib/python2.7/site-packages/txpostgres/txpostgres.py", line 689, in doRead
    self.reactor.addReader(self)
  File "/home/max/nxt/storesrv/venv/local/lib/python2.7/site-packages/twisted/internet/pollreactor.py", line 117, in addReader
    self._updateRegistration(fd)
  File "/home/max/nxt/storesrv/venv/local/lib/python2.7/site-packages/twisted/internet/pollreactor.py", line 74, in _updateRegistration
    self._poller.unregister(fd)
ValueError: file descriptor cannot be a negative integer (-1)
CONNECTION: <connection object at 0x2ac86b0; dsn: 'sslmode=require connect_timeout=5 keepalives_idle=5 keepalives_interval=5 keepalives_count=4 dbname=storage host=127.0.0.1 password=xxxxxxxxxx', closed: 0>
```
