### PR TITLE
Do not allow an asynchronous cursor to duplicate notifications to lis…

### DIFF
--- a/txpostgres/txpostgres.py
+++ b/txpostgres/txpostgres.py
@@ -697,7 +697,9 @@ class Connection(_PollingMixin):
             self.cooperator.cooperate(self._checkForNotifies())
 
     def _checkForNotifies(self):
-        for notify in self._connection.notifies:
+        current_notifications = self._connection.notifies[:]
+        del self._connection.notifies[:]
+        for notify in current_notifications:
             # don't iterate over self._notifyObservers directly because the
             # observer function might call removeNotifyObserver, thus modifying
             # the set while it's being iterated
@@ -708,8 +710,6 @@ class Connection(_PollingMixin):
                 # that would stop the cooperator from processing remaining
                 # observers
                 yield defer.maybeDeferred(observer, notify).addErrback(log.err)
-
-        del self._connection.notifies[:]
 
     def addNotifyObserver(self, observer):
         """


### PR DESCRIPTION
I noticed in my application code using 1.2.0 with notification order fix that a large number of notifications were getting duplicated after a transaction was completed. A total of 1613 notifications were coming from the database (confirmed in pgAdminIII).

A sample of debug output looks like:


```
# first transaction (works as expected)
CREATED CURSOR: <magdb.connection.Cursor object at 0x7fbaf642a290>
CLOSE CURSOR: <magdb.connection.Cursor object at 0x7fbaf642a290> 17
!!!!!!! CURRENT READ: 17
!!!!!!! TOTAL NOTIFICATIONS: 17

# second transaction (works as expected)
CREATED CURSOR: <magdb.connection.Cursor object at 0x7fbaf642a250>
CLOSE CURSOR: <magdb.connection.Cursor object at 0x7fbaf642a250> 17
!!!!!!! CURRENT READ: 17
!!!!!!! TOTAL NOTIFICATIONS: 34

# third transaction (duplicates some of the 1579 notifications)
CREATED CURSOR: <magdb.connection.Cursor object at 0x7f401ad8e2d0>
CLOSE CURSOR: <magdb.connection.Cursor object at 0x7f401ad8e2d0> 74
!!!!!!! CURRENT READ: 74
!!!!!!! TOTAL NOTIFICATIONS: 108
CREATED CURSOR: <magdb.connection.Cursor object at 0x7f401ad8e490>
CLOSE CURSOR: <magdb.connection.Cursor object at 0x7f401ad8e490> 1505
CREATED CURSOR: <magdb.connection.Cursor object at 0x7f401ad8e590>
!!!!!!! CURRENT READ: 1505
!!!!!!! TOTAL NOTIFICATIONS: 1613
CLOSE CURSOR: <magdb.connection.Cursor object at 0x7f401ad8e590> 1505
DUPLICATE  (detected identical 1505 notifications)
!!!!!!! CURRENT READ: 1505
!!!!!!! TOTAL NOTIFICATIONS: 3118
```